### PR TITLE
Add new file: trainers.py

### DIFF
--- a/trainers.py
+++ b/trainers.py
@@ -1,0 +1,206 @@
+"""Trainers for issue label classification models."""
+
+import logging
+import numpy as np
+import pickle
+from pathlib import Path
+from typing import List, Dict, Any, Optional
+from collections import Counter
+
+from sklearn.linear_model import LogisticRegression
+from sklearn.neural_network import MLPClassifier
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import MultiLabelBinarizer
+import xgboost as xgb
+
+logger = logging.getLogger(__name__)
+
+
+class LabelingModel:
+    """Multi-label issue classification models."""
+    
+    def __init__(self, model_type: str = "tfidf_logreg", random_state: int = 42):
+        """
+        Initialize labeling model.
+        
+        Args:
+            model_type: Type of model ('tfidf_logreg', 'embedding_logreg', 'mlp')
+            random_state: Random state for reproducibility
+        """
+        self.model_type = model_type
+        self.random_state = random_state
+        self.model = None
+        self.label_binarizer = MultiLabelBinarizer()
+        self.is_fitted = False
+        
+    def _create_model(self, embedding_dim: Optional[int] = None):
+        """Create the appropriate model based on model_type."""
+        if self.model_type == "tfidf_logreg":
+            self.model = Pipeline([
+                ('tfidf', TfidfVectorizer(max_features=5000, ngram_range=(1, 2))),
+                ('clf', LogisticRegression(
+                    max_iter=1000,
+                    random_state=self.random_state,
+                    verbose=0,
+                    n_jobs=-1
+                ))
+            ])
+        elif self.model_type == "embedding_logreg":
+            if embedding_dim is None:
+                raise ValueError("embedding_dim must be provided for embedding models")
+            self.model = LogisticRegression(
+                max_iter=1000,
+                random_state=self.random_state,
+                verbose=0
+            )
+        elif self.model_type == "mlp":
+            if embedding_dim is None:
+                raise ValueError("embedding_dim must be provided for MLP models")
+            self.model = MLPClassifier(
+                hidden_layer_sizes=(256, 128),
+                max_iter=500,
+                random_state=self.random_state,
+                verbose=False
+            )
+        elif self.model_type == "xgboost":
+            self.model = Pipeline([
+                ('tfidf', TfidfVectorizer(max_features=5000, ngram_range=(1, 2))),
+                ('clf', xgb.XGBClassifier(
+                    random_state=self.random_state,
+                    eval_metric='logloss',
+                    use_label_encoder=False,
+                    n_jobs=-1
+                ))
+            ])
+        else:
+            raise ValueError(f"Unknown model type: {self.model_type}")
+    
+    def fit(self, X: np.ndarray, y: List[List[str]]):
+        """
+        Train the labeling model.
+        
+        Args:
+            X: Feature matrix (text or embeddings)
+            y: List of label lists for each sample
+        """
+        if self.model is None:
+            self._create_model(embedding_dim=X.shape[1] if len(X.shape) > 1 else None)
+        
+        # Binarize labels
+        logger.info("Binarizing labels...")
+        y_binarized = self.label_binarizer.fit_transform(y)
+        logger.info(f"Created {len(self.label_binarizer.classes_)} label classes")
+        
+        logger.info(f"Training {self.model_type} model on {len(X)} samples")
+        
+        if self.model_type in ["embedding_logreg", "mlp"]:
+            # For embedding-based models, fit directly
+            self.model.fit(X, y_binarized)
+        else:
+            # For pipeline models, fit with text
+            self.model.fit(X, y)
+        
+        self.is_fitted = True
+        logger.info(f"{self.model_type} model trained successfully")
+    
+    def predict_proba(self, X: np.ndarray) -> np.ndarray:
+        """
+        Predict label probabilities.
+        
+        Args:
+            X: Feature matrix
+            
+        Returns:
+            Array of predicted probabilities
+        """
+        if not self.is_fitted:
+            raise RuntimeError("Model not fitted yet. Call fit() first.")
+        
+        if self.model_type in ["embedding_logreg", "mlp"]:
+            return self.model.predict_proba(X)
+        else:
+            # For pipeline models
+            return self.model.predict_proba(X)
+    
+    def predict(self, X: np.ndarray, threshold: float = 0.5) -> List[List[str]]:
+        """
+        Predict labels for samples.
+        
+        Args:
+            X: Feature matrix
+            threshold: Probability threshold for label assignment
+            
+        Returns:
+            List of predicted label lists
+        """
+        if not self.is_fitted:
+            raise RuntimeError("Model not fitted yet. Call fit() first.")
+        
+        probas = self.predict_proba(X)
+        
+        # Binary predictions based on threshold
+        predictions = (probas >= threshold).astype(int)
+        
+        # Convert back to label lists
+        label_lists = []
+        for pred in predictions:
+            labels = [
+                self.label_binarizer.classes_[i] 
+                for i, val in enumerate(pred) if val == 1
+            ]
+            label_lists.append(labels)
+        
+        return label_lists
+    
+    def get_label_counts(self, y: List[List[str]]) -> Dict[str, int]:
+        """
+        Get label frequency counts.
+        
+        Args:
+            y: List of label lists
+            
+        Returns:
+            Dictionary mapping labels to counts
+        """
+        all_labels = []
+        for labels in y:
+            all_labels.extend(labels)
+        
+        return Counter(all_labels)
+    
+    def save(self, file_path: Path):
+        """
+        Save the trained model.
+        
+        Args:
+            file_path: Path to save the model
+        """
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        
+        with open(file_path, 'wb') as f:
+            pickle.dump({
+                'model_type': self.model_type,
+                'model': self.model,
+                'label_binarizer': self.label_binarizer,
+                'is_fitted': self.is_fitted
+            }, f)
+        
+        logger.info(f"Saved labeling model to {file_path}")
+    
+    def load(self, file_path: Path):
+        """
+        Load a trained model.
+        
+        Args:
+            file_path: Path to the saved model
+        """
+        with open(file_path, 'rb') as f:
+            data = pickle.load(f)
+        
+        self.model_type = data['model_type']
+        self.model = data['model']
+        self.label_binarizer = data['label_binarizer']
+        self.is_fitted = data['is_fitted']
+        
+        logger.info(f"Loaded labeling model from {file_path}")


### PR DESCRIPTION
## Pull Request: trainers.py

### ✨ New File Addition

This PR introduces a new file to the repository.

### 📝 Code Summary
The `trainers.py` file defines a `LabelingModel` class designed for multi-label issue classification. It supports various model types including TF-IDF with Logistic Regression, embedding-based Logistic Regression, Multi-layer Perceptron (MLP), and TF-IDF with XGBoost. The class handles model initialization, training (`fit`), probability prediction (`predict_proba`), and label prediction (`predict`) using a binarized label representation. It also includes utilities for calculating label counts and saving/loading trained models using pickle.

### Key Changes
- Introduction of `LabelingModel` class for multi-label classification.
- Support for multiple model types: `tfidf_logreg`, `embedding_logreg`, `mlp`, and `xgboost`.
- Integrated `MultiLabelBinarizer` for handling multi-label targets.
- Conditional model creation within `_create_model` based on `model_type`.
- Separate handling in `fit` for pipeline models (TF-IDF based) vs. direct embedding-based models.
- Unified `predict_proba` and `predict` methods across different model types.
- Persistence methods (`save` and `load`) using `pickle` for model and binarizer.
- Improved logging throughout the training and loading processes.

### 🔍 Notes
- **undefined**: Loading models using `pickle.load()` from an untrusted source can lead to arbitrary code execution. While the current use implies loading self-saved models, it's a general security risk if `file_path` could ever point to an untrusted file.
- **undefined**: The `fit` method has a conditional logic for how `X` and `y` are passed to `self.model.fit`. For `tfidf_logreg` and `xgboost` (pipeline models), `self.model.fit(X, y)` is called, where `X` is assumed to be raw text and `y` is a list of label lists. For `embedding_logreg` and `mlp`, `self.model.fit(X, y_binarized)` is called, where `X` is already embeddings and `y_binarized` is a dense array. This inconsistency can lead to confusion or subtle bugs if not carefully managed by the caller. Specifically, `X` should always be the input features for the 'first' step of the model.
- **undefined**: The `predict_proba` method for `sklearn` classifiers (used in `embedding_logreg`, `mlp`, `tfidf_logreg`) returns probabilities per class. However, `XGBClassifier`'s `predict_proba` method in `xgboost` (when used in a multi-label context) often expects the input to be the binarized labels or may need more explicit handling for multi-label. If `XGBClassifier`'s `predict_proba` does not inherently produce per-label probabilities suitable for multi-label thresholding, this could be an issue. Sklearn's `LogisticRegression` usually handles multi-label via one-vs-rest (`OVR`) and provides a `predict_proba` for each class, which `MLPClassifier` also generally does. Ensure `xgb.XGBClassifier` behaves similarly here when `y` is a list of lists or needs `MultiOutputClassifier` wrapping.
- **undefined**: When using `xgboost` within the pipeline for multi-label classification, `xgb.XGBClassifier` does not natively handle multi-label output with a direct `predict_proba` for each label like `LogisticRegression` with `MultiLabelBinarizer` might when wrapped in `OneVsRestClassifier`. If `XGBClassifier` is used without an explicit `MultiOutputClassifier` wrapper for multi-label settings, its `predict_proba` will likely output for the 'last' class or be ill-defined for multi-label. This could lead to incorrect probability predictions for the multi-label case.
- **undefined**: The `verbose=0` setting for `LogisticRegression` and `verbose=False` for `MLPClassifier` are redundant. `verbose=0` or `verbose=False` is typically the default (and desired here to avoid excessive logging from the underlying sklearn models). While not an error, it's unnecessary to explicitly set them to their default values.
- **undefined**: The `use_label_encoder=False` parameter in `xgb.XGBClassifier` is set to suppress a future deprecation warning. While this works, it's good practice to be aware that in future XGBoost versions, this parameter might be removed entirely or its default behavior changed, potentially requiring updates.
- **undefined**: The type hint for `X` in `fit(self, X: np.ndarray, y: List[List[str]])` is `np.ndarray`. However, for `tfidf_logreg` and `xgboost` model types, `X` is expected to be a list of strings (raw text). This type hint is misleading or incorrect for those specific model types.
- **undefined**: The `embedding_dim` parameter in `_create_model` is only used for `embedding_logreg` and `mlp`. For `tfidf_logreg` and `xgboost`, it's not applicable. The way `_create_model` is called in `fit` is `self._create_model(embedding_dim=X.shape[1] if len(X.shape) > 1 else None)`. If `X` truly needs to be raw text for TF-IDF models, `X.shape[1]` would likely cause an error or produce an incorrect `embedding_dim` if `X` is a list of strings. A more robust check might be needed.
